### PR TITLE
Separate extractors from sanitizers.

### DIFF
--- a/lib/extract/documentURI.js
+++ b/lib/extract/documentURI.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Gets a `document-uri` from a CSP report payload.
+ *
+ * The `document-uri` property should be set on the `csp-report` object (i.e.,
+ * payload['csp-report']['document-uri']); however, some older browsers will
+ * send a `document-url` property on the payload object that contains the same
+ * information as the `document-uri` property. This function extracts a
+ * `document-uri` from the payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `document-uri` value.
+ */
+function getDocumentURI(payload) {
+  var uri = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('document-uri')) {
+    uri = payload['csp-report']['document-uri'];
+  } else if (payload.hasOwnProperty('document-url')) {
+    uri = payload['document-url'];
+  }
+
+  return uri;
+}
+
+module.exports = {
+  getDocumentURI: getDocumentURI,
+}

--- a/lib/sanitize/documentURI.js
+++ b/lib/sanitize/documentURI.js
@@ -4,29 +4,40 @@ var url = require('url');
 var validator = require('validator');
 
 /**
- * Sanitizes a `document-uri` or `document-url` value.
+ * Gets a `document-uri` from a CSP report payload.
  *
- * @param  {String}    documentURI    The raw `document-uri` value.
- * @param  {String}    documentURL    The raw `document-url` value. This value
- *                                    is present in reports sent by older
- *                                    browsers. It will mostly be an empty
- *                                    string, but needs to be considered when a
- *                                    document-uri is not available.
- * @return {String}                   The sanitized `document-uri` value.
+ * The `document-uri` property should be set on the `csp-report` object (i.e.,
+ * payload['csp-report']['document-uri']); however, some older browsers will
+ * send a `document-url` property on the payload object that contains the same
+ * information as the `document-uri` property. This function extracts a
+ * `document-uri` from the payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `document-uri` value.
  */
-function sanitize(documentURI, documentURL) {
-  var documentURL = documentURL || '';
+function getDocumentURI(payload) {
   var uri = '';
 
-  if ('' !== documentURI) {
-    uri = documentURI;
-  } else if ('' !== documentURL) {
-    uri = documentURL;
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('document-uri')) {
+    uri = payload['csp-report']['document-uri'];
+  } else if (payload.hasOwnProperty('document-url')) {
+    uri = payload['document-url'];
   }
 
+  return uri;
+}
+
+/**
+ * Sanitizes a `document-uri` value.
+ *
+ * @param  {String}    uri    The raw `document-uri` value.
+ * @return {String}           The sanitized `document-uri` value.
+ */
+function sanitize(uri) {
   return ('' !== uri && validator.isURL(uri)) ? uri : '';
 }
 
 module.exports = {
+  getDocumentURI: getDocumentURI,
   sanitize: sanitize
 }

--- a/lib/sanitize/documentURI.js
+++ b/lib/sanitize/documentURI.js
@@ -4,30 +4,6 @@ var url = require('url');
 var validator = require('validator');
 
 /**
- * Gets a `document-uri` from a CSP report payload.
- *
- * The `document-uri` property should be set on the `csp-report` object (i.e.,
- * payload['csp-report']['document-uri']); however, some older browsers will
- * send a `document-url` property on the payload object that contains the same
- * information as the `document-uri` property. This function extracts a
- * `document-uri` from the payload.
- *
- * @param  {Object}    payload    The CSP report body.
- * @return {String}               A `document-uri` value.
- */
-function getDocumentURI(payload) {
-  var uri = '';
-
-  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('document-uri')) {
-    uri = payload['csp-report']['document-uri'];
-  } else if (payload.hasOwnProperty('document-url')) {
-    uri = payload['document-url'];
-  }
-
-  return uri;
-}
-
-/**
  * Sanitizes a `document-uri` value.
  *
  * @param  {String}    uri    The raw `document-uri` value.
@@ -38,6 +14,5 @@ function sanitize(uri) {
 }
 
 module.exports = {
-  getDocumentURI: getDocumentURI,
   sanitize: sanitize
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Normalize Content Security Policy report payloads",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha -u tdd",
-    "test-cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec -u tdd",
-    "test-travis": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec -u tdd && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test": "./node_modules/.bin/mocha -u tdd --recursive",
+    "test-cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec -u tdd --recursive",
+    "test-travis": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec -u tdd  --recursive && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "lint": "jshint"
   },
   "repository": {

--- a/test/documentURI.js
+++ b/test/documentURI.js
@@ -2,6 +2,7 @@
 
 var assert = require('chai').assert;
 var sanitize = require('../lib/sanitize/documentURI').sanitize;
+var getDocumentURI = require('../lib/sanitize/documentURI').getDocumentURI;
 
 suite('sanitize', function() {
   suite('document-uri', function() {
@@ -33,14 +34,17 @@ suite('sanitize', function() {
       assert.equal(sanitize(ipWithoutProtocol), ipWithoutProtocol);
     });
 
-    test('document-url is used when document-uri is not available and document-url is and a valid URL is returned when passed', function() {
-      var documentURI = '';
-      var documentURL = 'http://example.com';
-      assert.equal(sanitize(documentURI, documentURL), documentURL);
+    test('getDocumentURI is a function', function() {
+      assert.isFunction(getDocumentURI);
     });
 
-    test('document-url is used when document-uri is not available and document-url is and an empty string is returned when passed an invalid URL', function() {
-      assert.equal(sanitize('', 'testing'), '');
+    test('document-url is used when document-uri is not available and document-url is and a valid URL is returned when passed', function() {
+      var url = 'http://example.com';
+      var payload = {
+        'document-url': url
+      };
+
+      assert.equal(getDocumentURI(payload), url);
     });
   });
 });

--- a/test/extract/documentURI.js
+++ b/test/extract/documentURI.js
@@ -9,13 +9,30 @@ suite('extract', function() {
       assert.isFunction(getDocumentURI);
     });
 
-    test('document-url is used when document-uri is not available and document-url is and a valid URL is returned when passed', function() {
+    test('document-uri is used when available', function() {
+      var url = 'http://example.com';
+      var payload = {
+        'csp-report': {
+          'document-uri': url
+        }
+      };
+
+      assert.equal(getDocumentURI(payload), url);
+    });
+
+    test('document-url is used when document-uri is not available', function() {
       var url = 'http://example.com';
       var payload = {
         'document-url': url
       };
 
       assert.equal(getDocumentURI(payload), url);
+    });
+
+    test('empty string is returned when neither document-uri or document-url are available', function() {
+      var payload = {};
+
+      assert.equal(getDocumentURI(payload), '');
     });
   });
 });

--- a/test/extract/documentURI.js
+++ b/test/extract/documentURI.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var assert = require('chai').assert;
+var getDocumentURI = require('../../lib/extract/documentURI').getDocumentURI;
+
+suite('extract', function() {
+  suite('document-uri', function() {
+    test('getDocumentURI is a function', function() {
+      assert.isFunction(getDocumentURI);
+    });
+
+    test('document-url is used when document-uri is not available and document-url is and a valid URL is returned when passed', function() {
+      var url = 'http://example.com';
+      var payload = {
+        'document-url': url
+      };
+
+      assert.equal(getDocumentURI(payload), url);
+    });
+  });
+});

--- a/test/sanitize/blockedURI.js
+++ b/test/sanitize/blockedURI.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var sanitize = require('../lib/sanitize/blockedURI').sanitize;
+var sanitize = require('../../lib/sanitize/blockedURI').sanitize;
 
 suite('sanitize', function() {
   suite('blocked-uri', function() {

--- a/test/sanitize/documentURI.js
+++ b/test/sanitize/documentURI.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var sanitize = require('../lib/sanitize/documentURI').sanitize;
-var getDocumentURI = require('../lib/sanitize/documentURI').getDocumentURI;
+var sanitize = require('../../lib/sanitize/documentURI').sanitize;
 
 suite('sanitize', function() {
   suite('document-uri', function() {
@@ -32,19 +31,6 @@ suite('sanitize', function() {
     test('IP address alone returns IP address alone', function() {
       var ipWithoutProtocol = 'http://127.0.0.1';
       assert.equal(sanitize(ipWithoutProtocol), ipWithoutProtocol);
-    });
-
-    test('getDocumentURI is a function', function() {
-      assert.isFunction(getDocumentURI);
-    });
-
-    test('document-url is used when document-uri is not available and document-url is and a valid URL is returned when passed', function() {
-      var url = 'http://example.com';
-      var payload = {
-        'document-url': url
-      };
-
-      assert.equal(getDocumentURI(payload), url);
     });
   });
 });

--- a/test/sanitize/statusCode.js
+++ b/test/sanitize/statusCode.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var sanitize = require('../lib/sanitize/statusCode').sanitize;
+var sanitize = require('../../lib/sanitize/statusCode').sanitize;
 
 suite('sanitize', function() {
   suite('status-code', function() {


### PR DESCRIPTION
It's becoming clear that with some properties there are two unique
processes, extracting and sanitizing. The extractors will usually take a
payload and find the right property based on whatever logic is
necessary. The sanitizers will then clean that value.

This branch will track work on setting up the architecture for having a
set of extractors and a set of sanitizers. These are separate concepts
and they should be treated separately.
