### PR TITLE
Add effective directive and violated directive.

### DIFF
--- a/lib/extract/documentURI.js
+++ b/lib/extract/documentURI.js
@@ -1,29 +1,15 @@
 'use strict';
 
-/**
- * Gets a `document-uri` from a CSP report payload.
- *
- * The `document-uri` property should be set on the `csp-report` object (i.e.,
- * payload['csp-report']['document-uri']); however, some older browsers will
- * send a `document-url` property on the payload object that contains the same
- * information as the `document-uri` property. This function extracts a
- * `document-uri` from the payload.
- *
- * @param  {Object}    payload    The CSP report body.
- * @return {String}               A `document-uri` value.
- */
-function getDocumentURI(payload) {
-  var uri = '';
+function extract(payload) {
+  var documentURI = '';
 
   if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('document-uri')) {
-    uri = payload['csp-report']['document-uri'];
-  } else if (payload.hasOwnProperty('document-url')) {
-    uri = payload['document-url'];
+    documentURI = payload['csp-report']['document-uri'];
   }
 
-  return uri;
+  return documentURI;
 }
 
 module.exports = {
-  getDocumentURI: getDocumentURI,
-}
+  extract: extract
+};

--- a/lib/extract/documentURI.js
+++ b/lib/extract/documentURI.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Gets a `document-uri` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `document-uri` value.
+ */
 function extract(payload) {
   var documentURI = '';
 

--- a/lib/extract/documentURL.js
+++ b/lib/extract/documentURL.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Gets a `document-url` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `document-url` value.
+ */
 function extract(payload) {
   var documentURL = '';
 

--- a/lib/extract/documentURL.js
+++ b/lib/extract/documentURL.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function extract(payload) {
+  var documentURL = '';
+
+  if (payload.hasOwnProperty('document-url')) {
+    documentURL = payload['document-url'];
+  }
+
+  return documentURL;
+}
+
+module.exports = {
+  extract: extract
+};

--- a/lib/extract/effectiveDirective.js
+++ b/lib/extract/effectiveDirective.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Gets the `effective-directive` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               An `effective-directive` value.
+ */
 function extract(payload) {
   var effectiveDirective = '';
 

--- a/lib/extract/effectiveDirective.js
+++ b/lib/extract/effectiveDirective.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var isValidEffectiveDirective = require('../util').isValidEffectiveDirective;
+
+function getEffectiveDirectiveFromEffectiveDirective(payload) {
+  var effectiveDirective = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('effective-directive') && isValidEffectiveDirective(payload['csp-report']['effective-directive'])) {
+    effectiveDirective = payload['csp-report']['effective-directive'];
+  }
+
+  return effectiveDirective;
+}
+
+function getEffectiveDirectiveFromDocumentURL(payload) {
+  var documentURL = '';
+
+  if (payload.hasOwnProperty('document-url')) {
+      documentURL = payload['document-url'];
+  }
+
+  return documentURL;
+}
+
+function getEffectiveDirective(payload) {
+  var effectiveDirective = getEffectiveDirectiveFromEffectiveDirective(payload);
+  var documentURL = getEffectiveDirectiveFromDocumentURL(payload);
+
+  return effectiveDirective;
+}
+
+function generateEffectiveDirectiveFromViolatedDirective(violatedDirective) {
+  var effectiveDirective = '';
+  var effectiveDirectives = getEffectiveDirectives();
+
+  // Attempt to match find an effective-directive that begins the violated
+  // directive
+  effectiveDirectives.forEach(function(value) {
+    if (0 === violatedDirective.indexOf(value)) {
+      effectiveDirective = value;
+    }
+  });
+
+  return effectiveDirective;
+}
+
+module.exports = {
+  getEffectiveDirectiveFromEffectiveDirective: getEffectiveDirectiveFromEffectiveDirective,
+  getEffectiveDirectiveFromDocumentURL: getEffectiveDirectiveFromDocumentURL,
+  getEffectiveDirective: getEffectiveDirective,
+  generateEffectiveDirectiveFromViolatedDirective: generateEffectiveDirectiveFromViolatedDirective
+}

--- a/lib/extract/effectiveDirective.js
+++ b/lib/extract/effectiveDirective.js
@@ -1,37 +1,15 @@
 'use strict';
 
-var isValidEffectiveDirective = require('../util').isValidEffectiveDirective;
-var getEffectiveDirectiveFromEffectiveDirective = require('../util').getEffectiveDirectiveFromEffectiveDirective;
-
-function getEffectiveDirective(payload) {
+function extract(payload) {
   var effectiveDirective = '';
-  var candidateEffectiveDirective = getEffectiveDirectiveFromEffectiveDirective(payload);
 
-  if ('' === candidateEffectiveDirective) {
-
-  } else {
-
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('effective-directive')) {
+    effectiveDirective = payload['csp-report']['effective-directive'];
   }
 
   return effectiveDirective;
 }
 
-function generateEffectiveDirectiveFromViolatedDirective(violatedDirective) {
-  var effectiveDirective = '';
-  var effectiveDirectives = getEffectiveDirectives();
-
-  // Attempt to match find an effective-directive that begins the violated
-  // directive
-  effectiveDirectives.forEach(function(value) {
-    if (0 === violatedDirective.indexOf(value)) {
-      effectiveDirective = value;
-    }
-  });
-
-  return effectiveDirective;
-}
-
 module.exports = {
-  getEffectiveDirective: getEffectiveDirective,
-  generateEffectiveDirectiveFromViolatedDirective: generateEffectiveDirectiveFromViolatedDirective
-}
+  extract: extract
+};

--- a/lib/extract/effectiveDirective.js
+++ b/lib/extract/effectiveDirective.js
@@ -1,30 +1,17 @@
 'use strict';
 
 var isValidEffectiveDirective = require('../util').isValidEffectiveDirective;
-
-function getEffectiveDirectiveFromEffectiveDirective(payload) {
-  var effectiveDirective = '';
-
-  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('effective-directive') && isValidEffectiveDirective(payload['csp-report']['effective-directive'])) {
-    effectiveDirective = payload['csp-report']['effective-directive'];
-  }
-
-  return effectiveDirective;
-}
-
-function getEffectiveDirectiveFromDocumentURL(payload) {
-  var documentURL = '';
-
-  if (payload.hasOwnProperty('document-url')) {
-      documentURL = payload['document-url'];
-  }
-
-  return documentURL;
-}
+var getEffectiveDirectiveFromEffectiveDirective = require('../util').getEffectiveDirectiveFromEffectiveDirective;
 
 function getEffectiveDirective(payload) {
-  var effectiveDirective = getEffectiveDirectiveFromEffectiveDirective(payload);
-  var documentURL = getEffectiveDirectiveFromDocumentURL(payload);
+  var effectiveDirective = '';
+  var candidateEffectiveDirective = getEffectiveDirectiveFromEffectiveDirective(payload);
+
+  if ('' === candidateEffectiveDirective) {
+
+  } else {
+
+  }
 
   return effectiveDirective;
 }
@@ -45,8 +32,6 @@ function generateEffectiveDirectiveFromViolatedDirective(violatedDirective) {
 }
 
 module.exports = {
-  getEffectiveDirectiveFromEffectiveDirective: getEffectiveDirectiveFromEffectiveDirective,
-  getEffectiveDirectiveFromDocumentURL: getEffectiveDirectiveFromDocumentURL,
   getEffectiveDirective: getEffectiveDirective,
   generateEffectiveDirectiveFromViolatedDirective: generateEffectiveDirectiveFromViolatedDirective
 }

--- a/lib/extract/violatedDirective.js
+++ b/lib/extract/violatedDirective.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function extract(payload) {
+  var violatedDirective = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('violated-directive')) {
+    violatedDirective = payload['csp-report']['violated-directive'];
+  }
+
+  return violatedDirective;
+}
+
+module.exports = {
+  extract: extract
+};

--- a/lib/extract/violatedDirective.js
+++ b/lib/extract/violatedDirective.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Gets the `violated-directive` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `violated-directive` value.
+ */
 function extract(payload) {
   var violatedDirective = '';
 

--- a/lib/get/documentURI.js
+++ b/lib/get/documentURI.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Gets a `document-uri` from a CSP report payload.
+ *
+ * The `document-uri` property should be set on the `csp-report` object (i.e.,
+ * payload['csp-report']['document-uri']); however, some older browsers will
+ * send a `document-url` property on the payload object that contains the same
+ * information as the `document-uri` property. This function extracts a
+ * `document-uri` from the payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `document-uri` value.
+ */
+function get(payload) {
+  var uri = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('document-uri')) {
+    uri = payload['csp-report']['document-uri'];
+  } else if (payload.hasOwnProperty('document-url')) {
+    uri = payload['document-url'];
+  }
+
+  return uri;
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/get/effectiveDirective.js
+++ b/lib/get/effectiveDirective.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var extractEffectiveDirective = require('../extract/effectiveDirective').extract;
+var getViolatedDirective = require('../get/violatedDirective').get;
+var isValidEffectiveDirective = require('../validate/effectiveDirective').validate;
+var getDirectives = require('../util').getDirectives;
+
+function get(payload) {
+  var effectiveDirective = '';
+  var candidateEffectiveDirective = extractEffectiveDirective(payload);
+  var violatedDirective = getViolatedDirective(payload);
+
+  if (isValidEffectiveDirective(candidateEffectiveDirective)) {
+    effectiveDirective = candidateEffectiveDirective;
+  } else if ('' !== violatedDirective) {
+    effectiveDirective = generateEffectiveDirectiveFromViolatedDirective(violatedDirective);
+  }
+
+  return effectiveDirective;
+}
+
+function generateEffectiveDirectiveFromViolatedDirective(violatedDirective) {
+  var effectiveDirective = '';
+  var directives = getDirectives();
+
+  // Attempt to match find an effective-directive that begins the violated
+  // directive
+  directives.forEach(function(value) {
+    if (0 === violatedDirective.indexOf(value)) {
+      effectiveDirective = value;
+    }
+  });
+
+  return effectiveDirective;
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/get/effectiveDirective.js
+++ b/lib/get/effectiveDirective.js
@@ -5,6 +5,15 @@ var getViolatedDirective = require('../get/violatedDirective').get;
 var isValidEffectiveDirective = require('../validate/effectiveDirective').validate;
 var getDirectives = require('../util').getDirectives;
 
+/**
+ * Gets the `effective-directive` for a CSP report.
+ *
+ * Attempts to extract the `effective-directive` from the report and if not
+ * found, derives it from the `violated-directive` value for the report.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               An `effective-directive` value.
+ */
 function get(payload) {
   var effectiveDirective = '';
   var candidateEffectiveDirective = extractEffectiveDirective(payload);
@@ -19,6 +28,12 @@ function get(payload) {
   return effectiveDirective;
 }
 
+/**
+ * Derives an `effective-directive` from a `violated-directive`.
+ *
+ * @param  {String}    violatedDirective    The `violated-directive` value.
+ * @return {String}                         An `effective-directive` value.
+ */
 function generateEffectiveDirectiveFromViolatedDirective(violatedDirective) {
   var effectiveDirective = '';
   var directives = getDirectives();

--- a/lib/get/violatedDirective.js
+++ b/lib/get/violatedDirective.js
@@ -3,6 +3,12 @@
 var extractViolatedDirective = require('../extract/violatedDirective').extract;
 var sanitizeViolatedDirective = require('../sanitize/violatedDirective').sanitize;
 
+/**
+ * Gets the `violated-directive` from a CSP report.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               An `violated-directive` value.
+ */
 function get(payload) {
   var candidateViolatedDirective = extractViolatedDirective(payload);
   return sanitizeViolatedDirective(candidateViolatedDirective);

--- a/lib/get/violatedDirective.js
+++ b/lib/get/violatedDirective.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var extractViolatedDirective = require('../extract/violatedDirective').extract;
+var sanitizeViolatedDirective = require('../sanitize/violatedDirective').sanitize;
+
+function get(payload) {
+  var candidateViolatedDirective = extractViolatedDirective(payload);
+  return sanitizeViolatedDirective(candidateViolatedDirective);
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/sanitize/blockedURI.js
+++ b/lib/sanitize/blockedURI.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var getGloballyUniqueIdentifiers = require('../util').getGloballyUniqueIdentifiers;
 var isGloballyUniqueIdentifier = require('../util').isGloballyUniqueIdentifier;
 var sanitizeGloballyUniqueIdentifier = require('../util').sanitizeGloballyUniqueIdentifier;
 var url = require('url');

--- a/lib/sanitize/documentURI.js
+++ b/lib/sanitize/documentURI.js
@@ -15,4 +15,4 @@ function sanitize(uri) {
 
 module.exports = {
   sanitize: sanitize
-}
+};

--- a/lib/sanitize/documentURI.js
+++ b/lib/sanitize/documentURI.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var url = require('url');
 var validator = require('validator');
 
 /**

--- a/lib/sanitize/statusCode.js
+++ b/lib/sanitize/statusCode.js
@@ -15,4 +15,4 @@ function sanitize(statusCode) {
 
 module.exports = {
   sanitize: sanitize
-}
+};

--- a/lib/sanitize/statusCode.js
+++ b/lib/sanitize/statusCode.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var url = require('url');
 var validator = require('validator');
 
 /**

--- a/lib/sanitize/violatedDirective.js
+++ b/lib/sanitize/violatedDirective.js
@@ -1,5 +1,12 @@
 'use strict';
 
+/**
+ * Sanitizes a `violated-directive` value.
+ *
+ * @param  {String}    violatedDirective    The raw `violated-directiv` value.
+ * @return {String}                         The sanitized `violated-directive`
+ *                                          value.
+ */
 function sanitize(violatedDirective) {
   return violatedDirective;
 }

--- a/lib/sanitize/violatedDirective.js
+++ b/lib/sanitize/violatedDirective.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function sanitize(violatedDirective) {
+  return violatedDirective;
+}
+
+module.exports = {
+  sanitize: sanitize
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -97,10 +97,21 @@ function isValidEffectiveDirective(effectiveDirective) {
   return result;
 }
 
+function getEffectiveDirectiveFromEffectiveDirective(payload) {
+  var effectiveDirective = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('effective-directive') && isValidEffectiveDirective(payload['csp-report']['effective-directive'])) {
+    effectiveDirective = payload['csp-report']['effective-directive'];
+  }
+
+  return effectiveDirective;
+}
+
 module.exports = {
   getGloballyUniqueIdentifiers: getGloballyUniqueIdentifiers,
   isGloballyUniqueIdentifier: isGloballyUniqueIdentifier,
   sanitizeGloballyUniqueIdentifier: sanitizeGloballyUniqueIdentifier,
   getDirectives: getDirectives,
-  isValidEffectiveDirective: isValidEffectiveDirective
+  isValidEffectiveDirective: isValidEffectiveDirective,
+  getEffectiveDirectiveFromEffectiveDirective: getEffectiveDirectiveFromEffectiveDirective
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,41 +77,9 @@ function getDirectives() {
   ];
 }
 
-/**
- * Determine if the effective-directive is valid.
- *
- * @param  {String}    effectiveDirective    The directive to test.
- * @return {Bool}                            Whether or not the directive is
- *                                           valid.
- */
-function isValidEffectiveDirective(effectiveDirective) {
-  var directives = getDirectives();
-  var result = false;
-
-  directives.forEach(function(directive) {
-    if (directive === effectiveDirective) {
-      result = true;
-    }
-  });
-
-  return result;
-}
-
-function getEffectiveDirectiveFromEffectiveDirective(payload) {
-  var effectiveDirective = '';
-
-  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('effective-directive') && isValidEffectiveDirective(payload['csp-report']['effective-directive'])) {
-    effectiveDirective = payload['csp-report']['effective-directive'];
-  }
-
-  return effectiveDirective;
-}
-
 module.exports = {
   getGloballyUniqueIdentifiers: getGloballyUniqueIdentifiers,
   isGloballyUniqueIdentifier: isGloballyUniqueIdentifier,
   sanitizeGloballyUniqueIdentifier: sanitizeGloballyUniqueIdentifier,
   getDirectives: getDirectives,
-  isValidEffectiveDirective: isValidEffectiveDirective,
-  getEffectiveDirectiveFromEffectiveDirective: getEffectiveDirectiveFromEffectiveDirective
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,8 +52,55 @@ function sanitizeGloballyUniqueIdentifier(value) {
   return cleanValue;
 }
 
+/**
+ * List of possible CSP directives.
+ *
+ * @return {Array}    CSP directives.
+ */
+function getDirectives() {
+  return [
+    'base-uri',
+    'child-src',
+    'connect-src',
+    'font-src',
+    'form-action',
+    'frame-ancestors',
+    'frame-src',
+    'img-src',
+    'media-src',
+    'object-src',
+    'plugin-types',
+    'report-uri',
+    'script-src',
+    'sandbox',
+    'style-src'
+  ];
+}
+
+/**
+ * Determine if the effective-directive is valid.
+ *
+ * @param  {String}    effectiveDirective    The directive to test.
+ * @return {Bool}                            Whether or not the directive is
+ *                                           valid.
+ */
+function isValidEffectiveDirective(effectiveDirective) {
+  var directives = getDirectives();
+  var result = false;
+
+  directives.forEach(function(directive) {
+    if (directive === effectiveDirective) {
+      result = true;
+    }
+  });
+
+  return result;
+}
+
 module.exports = {
   getGloballyUniqueIdentifiers: getGloballyUniqueIdentifiers,
   isGloballyUniqueIdentifier: isGloballyUniqueIdentifier,
-  sanitizeGloballyUniqueIdentifier: sanitizeGloballyUniqueIdentifier
+  sanitizeGloballyUniqueIdentifier: sanitizeGloballyUniqueIdentifier,
+  getDirectives: getDirectives,
+  isValidEffectiveDirective: isValidEffectiveDirective
 };

--- a/lib/validate/effectiveDirective.js
+++ b/lib/validate/effectiveDirective.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var getDirectives = require('../util').getDirectives;
+
+/**
+ * Determine if the effective-directive is valid.
+ *
+ * @param  {String}    effectiveDirective    The directive to test.
+ * @return {Bool}                            Whether or not the directive is
+ *                                           valid.
+ */
+function validate(effectiveDirective) {
+  var directives = getDirectives();
+  var result = false;
+
+  directives.forEach(function(directive) {
+    if (directive === effectiveDirective) {
+      result = true;
+    }
+  });
+
+  return result;
+}
+
+module.exports = {
+  validate: validate
+}

--- a/lib/validate/effectiveDirective.js
+++ b/lib/validate/effectiveDirective.js
@@ -24,4 +24,4 @@ function validate(effectiveDirective) {
 
 module.exports = {
   validate: validate
-}
+};

--- a/test/extract/documentURL.js
+++ b/test/extract/documentURL.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var extract = require('../../lib/extract/documentURI').extract;
+var extract = require('../../lib/extract/documentURL').extract;
 
 suite(__dirname.split('/').pop(), function() {
   suite(__filename.split('/').pop().replace('.js', ''), function() {
@@ -9,28 +9,17 @@ suite(__dirname.split('/').pop(), function() {
       assert.isFunction(extract);
     });
 
-    test('document-uri is used when available', function() {
+    test('document-url is used when available', function() {
       var url = 'http://example.com';
       var payload = {
-        'csp-report': {
-          'document-uri': url
-        }
+        'document-url': url
       };
 
       assert.equal(extract(payload), url);
     });
 
-    test('empty string when csp-report is set and the document-uri is not set', function() {
-      var payload = {
-        'csp-report': ''
-      };
-
-      assert.equal(extract(payload), '');
-    });
-
-    test('empty string is returned when payload is empty', function() {
+    test('empty string when document-url is not set', function() {
       var payload = {};
-
       assert.equal(extract(payload), '');
     });
   });

--- a/test/extract/effectiveDirective.js
+++ b/test/extract/effectiveDirective.js
@@ -3,8 +3,6 @@
 var assert = require('chai').assert;
 var getEffectiveDirective = require('../../lib/extract/effectiveDirective').getEffectiveDirective;
 var generateEffectiveDirectiveFromViolatedDirective = require('../../lib/extract/effectiveDirective').generateEffectiveDirectiveFromViolatedDirective;
-var getEffectiveDirectiveFromEffectiveDirective = require('../../lib/extract/effectiveDirective').getEffectiveDirectiveFromEffectiveDirective;
-var getEffectiveDirectiveFromDocumentURL = require('../../lib/extract/effectiveDirective').getEffectiveDirectiveFromDocumentURL;
 
 suite(__dirname.split('/').pop(), function() {
   suite(__filename.split('/').pop().replace('.js', ''), function() {
@@ -14,44 +12,6 @@ suite(__dirname.split('/').pop(), function() {
 
     test('generateEffectiveDirectiveFromViolatedDirective is a function', function() {
       assert.isFunction(generateEffectiveDirectiveFromViolatedDirective);
-    });
-
-    test('getEffectiveDirectiveFromEffectiveDirective is a function', function() {
-      assert.isFunction(getEffectiveDirectiveFromEffectiveDirective);
-    });
-
-    test('getEffectiveDirectiveFromDocumentURL is a function', function() {
-      assert.isFunction(getEffectiveDirectiveFromDocumentURL);
-    });
-
-    test('return effective-directive when getting it and one exists', function() {
-      var effectiveDirective = 'img-src';
-      var payload = {
-        'csp-report': {
-          'effective-directive': effectiveDirective
-        }
-      };
-
-      assert.equal(getEffectiveDirective(payload), effectiveDirective);
-    });
-
-    test('return empty string when getting effectiveDirective and one does not exist', function() {
-      var payload = {
-        'csp-report': {}
-      };
-
-      assert.equal(getEffectiveDirective(payload), '');
-      assert.equal(getEffectiveDirective({}), '');
-    });
-
-    test('return empty string when getting effectiveDirective and one does not exist, but is not valid', function() {
-      var payload = {
-        'csp-report': {
-          'effective-directive': 'blah'
-        }
-      };
-
-      assert.equal(getEffectiveDirective(payload), '');
     });
 
     test('return effective-directive when one exists', function() {

--- a/test/extract/effectiveDirective.js
+++ b/test/extract/effectiveDirective.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var assert = require('chai').assert;
+var getEffectiveDirective = require('../../lib/extract/effectiveDirective').getEffectiveDirective;
+var generateEffectiveDirectiveFromViolatedDirective = require('../../lib/extract/effectiveDirective').generateEffectiveDirectiveFromViolatedDirective;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('getEffectiveDirective is a function', function() {
+      assert.isFunction(getEffectiveDirective);
+    });
+
+    test('generateEffectiveDirectiveFromViolatedDirective is a function', function() {
+      assert.isFunction(generateEffectiveDirectiveFromViolatedDirective);
+    });
+
+    test('return effective-directive when one exists', function() {
+      var effectiveDirective = 'img-src';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when effective-directive is empty', function() {
+      var effectiveDirective = '';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when effective-directive is empty and violated-directive exists', function() {
+      var effectiveDirective = '';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective,
+          'violated-directive': 'img-src \'self\''
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when effective-directive and violated-directive are empty', function() {
+      var effectiveDirective = violatedDirective = '';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective,
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when effective-directive and violated-directive are not present', function() {
+      assert.equal(getEffectiveDirective({}), '');
+    });
+
+    test('generate effective-directive when effective-directive is missing and violated-directive exists', function() {
+      var effectiveDirective = 'img-src';
+      var violatedDirective = effectiveDirective + ' \'self\'';
+      var payload = {
+        'csp-report': {
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+  });
+});

--- a/test/extract/effectiveDirective.js
+++ b/test/extract/effectiveDirective.js
@@ -3,6 +3,8 @@
 var assert = require('chai').assert;
 var getEffectiveDirective = require('../../lib/extract/effectiveDirective').getEffectiveDirective;
 var generateEffectiveDirectiveFromViolatedDirective = require('../../lib/extract/effectiveDirective').generateEffectiveDirectiveFromViolatedDirective;
+var getEffectiveDirectiveFromEffectiveDirective = require('../../lib/extract/effectiveDirective').getEffectiveDirectiveFromEffectiveDirective;
+var getEffectiveDirectiveFromDocumentURL = require('../../lib/extract/effectiveDirective').getEffectiveDirectiveFromDocumentURL;
 
 suite(__dirname.split('/').pop(), function() {
   suite(__filename.split('/').pop().replace('.js', ''), function() {
@@ -12,6 +14,44 @@ suite(__dirname.split('/').pop(), function() {
 
     test('generateEffectiveDirectiveFromViolatedDirective is a function', function() {
       assert.isFunction(generateEffectiveDirectiveFromViolatedDirective);
+    });
+
+    test('getEffectiveDirectiveFromEffectiveDirective is a function', function() {
+      assert.isFunction(getEffectiveDirectiveFromEffectiveDirective);
+    });
+
+    test('getEffectiveDirectiveFromDocumentURL is a function', function() {
+      assert.isFunction(getEffectiveDirectiveFromDocumentURL);
+    });
+
+    test('return effective-directive when getting it and one exists', function() {
+      var effectiveDirective = 'img-src';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when getting effectiveDirective and one does not exist', function() {
+      var payload = {
+        'csp-report': {}
+      };
+
+      assert.equal(getEffectiveDirective(payload), '');
+      assert.equal(getEffectiveDirective({}), '');
+    });
+
+    test('return empty string when getting effectiveDirective and one does not exist, but is not valid', function() {
+      var payload = {
+        'csp-report': {
+          'effective-directive': 'blah'
+        }
+      };
+
+      assert.equal(getEffectiveDirective(payload), '');
     });
 
     test('return effective-directive when one exists', function() {

--- a/test/extract/violatedDirective.js
+++ b/test/extract/violatedDirective.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var extract = require('../../lib/extract/effectiveDirective').extract;
+var extract = require('../../lib/extract/violatedDirective').extract;
 
 suite(__dirname.split('/').pop(), function() {
   suite(__filename.split('/').pop().replace('.js', ''), function() {
@@ -10,17 +10,17 @@ suite(__dirname.split('/').pop(), function() {
     });
 
     test('extract finds directive when it exists', function() {
-      var effectiveDirective = 'img-src';
+      var effectiveDirective = 'img-src \'self\'';
       var report = {
         'csp-report': {
-          'effective-directive': effectiveDirective
+          'violated-directive': effectiveDirective
         }
       };
 
       assert.equal(extract(report), effectiveDirective);
     });
 
-    test('extract returns empty string when `effective-directive` is not set', function() {
+    test('extract returns empty string when `violated-directive` is not set', function() {
       var report = {
         'csp-report': {}
       };

--- a/test/get/documentURI.js
+++ b/test/get/documentURI.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var assert = require('chai').assert;
-var extract = require('../../lib/extract/documentURI').extract;
+var get = require('../../lib/get/documentURI').get;
 
 suite(__dirname.split('/').pop(), function() {
   suite(__filename.split('/').pop().replace('.js', ''), function() {
-    test('extract is a function', function() {
-      assert.isFunction(extract);
+    test('get is a function', function() {
+      assert.isFunction(get);
     });
 
     test('document-uri is used when available', function() {
@@ -17,7 +17,7 @@ suite(__dirname.split('/').pop(), function() {
         }
       };
 
-      assert.equal(extract(payload), url);
+      assert.equal(get(payload), url);
     });
 
     test('empty string when csp-report is set and the document-uri is not set', function() {
@@ -25,13 +25,22 @@ suite(__dirname.split('/').pop(), function() {
         'csp-report': ''
       };
 
-      assert.equal(extract(payload), '');
+      assert.equal(get(payload), '');
     });
 
-    test('empty string is returned when payload is empty', function() {
+    test('document-url is used when document-uri is not available', function() {
+      var url = 'http://example.com';
+      var payload = {
+        'document-url': url
+      };
+
+      assert.equal(get(payload), url);
+    });
+
+    test('empty string is returned when neither document-uri or document-url are available', function() {
       var payload = {};
 
-      assert.equal(extract(payload), '');
+      assert.equal(get(payload), '');
     });
   });
 });

--- a/test/get/effectiveDirective.js
+++ b/test/get/effectiveDirective.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var assert = require('chai').assert;
+var get = require('../../lib/get/effectiveDirective').get;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('get is a function', function() {
+      assert.isFunction(get);
+    });
+
+    test('returns effective directive correctly when passed effective directive', function() {
+      var effectiveDirective = 'style-src';
+      var report = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(get(report), effectiveDirective);
+    });
+
+    test('returns effective directive correctly when passed violated directive and no effective directive', function() {
+      var effectiveDirective = 'style-src';
+      var violatedDirective = 'style-src http://example.com';
+      var report = {
+        'csp-report': {
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(get(report), effectiveDirective);
+    });
+
+    test('returns empty string when effective directive is not a proper effective directive and no violated directive is passed', function() {
+      var effectiveDirective = 'blah';
+      var report = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(get(report), '');
+    });
+
+    test('returns effective directive when effective directive is not a proper effective directive and a violated directive is passed', function() {
+      var passedEffectiveDirective = 'blah';
+      var expectedEffectiveDirective = 'style-src';
+      var violatedDirective = 'style-src http://example.com';
+      var report = {
+        'csp-report': {
+          'effective-directive': passedEffectiveDirective,
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(get(report), expectedEffectiveDirective);
+    });
+
+    test('returns effective directive when effective directive is empty and a violated directive is passed', function() {
+      var passedEffectiveDirective = '';
+      var expectedEffectiveDirective = 'style-src';
+      var violatedDirective = 'style-src http://example.com';
+      var report = {
+        'csp-report': {
+          'effective-directive': passedEffectiveDirective,
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(get(report), expectedEffectiveDirective);
+    });
+
+    test('returns empty string both effective directive and violated directives are passed and empty', function() {
+      var report = {
+        'csp-report': {
+          'effective-directive': '',
+          'violated-directive': ''
+        }
+      };
+
+      assert.equal(get(report), '');
+    });
+  });
+});

--- a/test/get/violatedDirective.js
+++ b/test/get/violatedDirective.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var assert = require('chai').assert;
+var get = require('../../lib/get/violatedDirective').get;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('get is a function', function() {
+      assert.isFunction(get);
+    });
+
+    test.skip('returns violated directive correctly when passed violated directive', function() {
+      var violatedDirective = 'style-src http://example.com';
+      var report = {
+        'csp-report': {
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(get(report), violatedDirective);
+    });
+
+    test.skip('returns empty string when directive is not proper', function() {
+      var violatedDirective = 'blah http://example.com';
+      var report = {
+        'csp-report': {
+          'violated-directive': violatedDirective
+        }
+      };
+
+      assert.equal(get(report), '');
+    });
+  });
+});

--- a/test/sanitize/violatedDirective.js
+++ b/test/sanitize/violatedDirective.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var assert = require('chai').assert;
+var sanitize = require('../../lib/sanitize/violatedDirective').sanitize;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('sanitize is a function', function() {
+      assert.isFunction(sanitize);
+    });
+  });
+});

--- a/test/util.js
+++ b/test/util.js
@@ -63,6 +63,10 @@ suite(__filename.split('/').pop().replace('.js', ''), function() {
   });
 
   suite('directive functions', function() {
+    test('getDirectives is a function', function() {
+      assert.isFunction(util.getDirectives);
+    });
+
     test('ensure getDirectives returns the right directives', function() {
       assert.deepEqual(util.getDirectives(), [
           'base-uri',
@@ -82,48 +86,6 @@ suite(__filename.split('/').pop().replace('.js', ''), function() {
           'style-src'
         ]
       );
-    });
-
-    test('valid effective directive is true', function() {
-      assert.isTrue(util.isValidEffectiveDirective('img-src'));
-    });
-
-    test('invalid effective directive is false', function() {
-      assert.isFalse(util.isValidEffectiveDirective('blah'));
-    });
-
-    test('getEffectiveDirectiveFromEffectiveDirective is a function', function() {
-      assert.isFunction(util.getEffectiveDirectiveFromEffectiveDirective);
-    });
-
-    test('return effective-directive when getting it and one exists', function() {
-      var effectiveDirective = 'img-src';
-      var payload = {
-        'csp-report': {
-          'effective-directive': effectiveDirective
-        }
-      };
-
-      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), effectiveDirective);
-    });
-
-    test('return empty string when getting effectiveDirective and one does not exist', function() {
-      var payload = {
-        'csp-report': {}
-      };
-
-      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), '');
-      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective({}), '');
-    });
-
-    test('return empty string when getting effectiveDirective and one does not exist, but is not valid', function() {
-      var payload = {
-        'csp-report': {
-          'effective-directive': 'blah'
-        }
-      };
-
-      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), '');
     });
   });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -61,4 +61,35 @@ suite(__filename.split('/').pop().replace('.js', ''), function() {
       assert.equal(util.sanitizeGloballyUniqueIdentifier('filesystem'), 'filesystem');
     });
   });
+
+  suite('directive functions', function() {
+    test('ensure getDirectives returns the right directives', function() {
+      assert.deepEqual(util.getDirectives(), [
+          'base-uri',
+          'child-src',
+          'connect-src',
+          'font-src',
+          'form-action',
+          'frame-ancestors',
+          'frame-src',
+          'img-src',
+          'media-src',
+          'object-src',
+          'plugin-types',
+          'report-uri',
+          'script-src',
+          'sandbox',
+          'style-src'
+        ]
+      );
+    });
+
+    test('valid effective directive is true', function() {
+      assert.isTrue(util.isValidEffectiveDirective('img-src'));
+    });
+
+    test('invalid effective directive is false', function() {
+      assert.isFalse(util.isValidEffectiveDirective('blah'));
+    });
+  });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -91,5 +91,39 @@ suite(__filename.split('/').pop().replace('.js', ''), function() {
     test('invalid effective directive is false', function() {
       assert.isFalse(util.isValidEffectiveDirective('blah'));
     });
+
+    test('getEffectiveDirectiveFromEffectiveDirective is a function', function() {
+      assert.isFunction(util.getEffectiveDirectiveFromEffectiveDirective);
+    });
+
+    test('return effective-directive when getting it and one exists', function() {
+      var effectiveDirective = 'img-src';
+      var payload = {
+        'csp-report': {
+          'effective-directive': effectiveDirective
+        }
+      };
+
+      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), effectiveDirective);
+    });
+
+    test('return empty string when getting effectiveDirective and one does not exist', function() {
+      var payload = {
+        'csp-report': {}
+      };
+
+      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), '');
+      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective({}), '');
+    });
+
+    test('return empty string when getting effectiveDirective and one does not exist, but is not valid', function() {
+      var payload = {
+        'csp-report': {
+          'effective-directive': 'blah'
+        }
+      };
+
+      assert.equal(util.getEffectiveDirectiveFromEffectiveDirective(payload), '');
+    });
   });
 });

--- a/test/validate/effectiveDirective.js
+++ b/test/validate/effectiveDirective.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var assert = require('chai').assert;
+var validate = require('../../lib/validate/effectiveDirective').validate;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('validate is a function', function() {
+      assert.isFunction(validate);
+    });
+
+    test('returns true when directive is valid', function() {
+      assert.isTrue(validate('base-uri'));
+      assert.isTrue(validate('child-src'));
+      assert.isTrue(validate('connect-src'));
+      assert.isTrue(validate('font-src'));
+      assert.isTrue(validate('form-action'));
+      assert.isTrue(validate('frame-ancestors'));
+      assert.isTrue(validate('frame-src'));
+      assert.isTrue(validate('img-src'));
+      assert.isTrue(validate('media-src'));
+      assert.isTrue(validate('object-src'));
+      assert.isTrue(validate('plugin-types'));
+      assert.isTrue(validate('report-uri'));
+      assert.isTrue(validate('script-src'));
+      assert.isTrue(validate('sandbox'));
+      assert.isTrue(validate('style-src'));
+    });
+
+    test('returns false when directive is not-valid', function() {
+      assert.isFalse(validate(''));
+      assert.isFalse(validate('blah'));
+      assert.isFalse(validate('img-src-blah'));
+      assert.isFalse(validate('blah-img-src'));
+    });
+  });
+});


### PR DESCRIPTION
This PR is turning into more than originally planned, but the main focus to get the effective and violated directives extracted. These two values are related as I will use the violated directive to ascertain the effective directive if it is not sent. This is crucial as the effective directive is only send via Blink based browsers at the time of this PR. We want to extract that value (because we can) when we can do it.

Additionally, in the process of handling this feature, it became clear that a refactor was in order. From the commit:

> Refactored functionality for effective directive into 4 parts: extract,
> validate, sanitize, and get. Effective directive and violated directive
> now use this 4 processes. Others will be migrated to this format as
> well.
> 
> This change was necessary to handle all of the needs of getting the
> effective directive. Essentially, you must first extract the data from
> the report. Then, depending on the type of data, you must either
> sanitize or validate it. Finally, the "get" functionality is what wraps
> these subprocesses and produces a final result.
> 
> This process works well for effective directives and should be utilized
> for others. This is particularly helpful for more complex data where
> multiple processes are needed.
