### PR TITLE
Add the remaining CSP report fields

### DIFF
--- a/lib/extract/columnNumber.js
+++ b/lib/extract/columnNumber.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Gets the `column-number` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `column-number` value.
+ */
+function extract(payload) {
+  var columnNumber = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('column-number')) {
+    columnNumber = payload['csp-report']['column-number'];
+  }
+
+  return columnNumber;
+}
+
+module.exports = {
+  extract: extract
+};

--- a/lib/extract/lineNumber.js
+++ b/lib/extract/lineNumber.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Gets the `line-number` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `line-number` value.
+ */
+function extract(payload) {
+  var lineNumber = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('line-number')) {
+    lineNumber = payload['csp-report']['line-number'];
+  }
+
+  return lineNumber;
+}
+
+module.exports = {
+  extract: extract
+};

--- a/lib/extract/sourceFile.js
+++ b/lib/extract/sourceFile.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Gets the `source-file` from a CSP report payload.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @return {String}               A `source-file` value.
+ */
+function extract(payload) {
+  var sourceFile = '';
+
+  if (payload.hasOwnProperty('csp-report') && payload['csp-report'].hasOwnProperty('source-file')) {
+    sourceFile = payload['csp-report']['source-file'];
+  }
+
+  return sourceFile;
+}
+
+module.exports = {
+  extract: extract
+};

--- a/lib/get/columnNumber.js
+++ b/lib/get/columnNumber.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var extractColumnNumber = require('../extract/columnNumber').extract;
+var sanitizeColumnNumber = require('../sanitize/columnNumber').sanitize;
+
+/**
+ * Gets the `column-number` from a CSP report.
+ *
+ * @param  {Object}     payload    The CSP report body.
+ * @return {Integer}               An `column-number` value.
+ */
+function get(payload) {
+  var candidateColumnNumber = extractColumnNumber(payload);
+  return sanitizeColumnNumber(candidateColumnNumber);
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/get/lineNumber.js
+++ b/lib/get/lineNumber.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var extractLineNumber = require('../extract/lineNumber').extract;
+var sanitizeLineNumber = require('../sanitize/lineNumber').sanitize;
+
+/**
+ * Gets the `line-number` from a CSP report.
+ *
+ * @param  {Object}     payload    The CSP report body.
+ * @return {Integer}               An `line-number` value.
+ */
+function get(payload) {
+  var candidateLineNumber = extractLineNumber(payload);
+  return sanitizeLineNumber(candidateLineNumber);
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/get/sourceFile.js
+++ b/lib/get/sourceFile.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var extractSourceFile = require('../extract/sourceFile').extract;
+var sanitizeSourceFile = require('../sanitize/sourceFile').sanitize;
+
+/**
+ * Gets the `source-file` from a CSP report.
+ *
+ * @param  {Object}    payload    The CSP report body.
+ * @param  {Object}    headers    The headers for the request.
+ * @return {String}               An `source-file` value.
+ */
+function get(payload, headers) {
+  var candidateSourceFile = extractSourceFile(payload);
+
+  // The protected resource is the resource that the CSP is applied to. This can be a lot of things, but typically will
+  // refer to the main HTML for a webpage. Here, the assumption is made that the protected resource is the request
+  // referer
+  var protectedResource = (headers.hasOwnProperty('referer')) ? headers.referer : '';
+
+  return sanitizeSourceFile(candidateSourceFile, protectedResource);
+}
+
+module.exports = {
+  get: get
+};

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -7,6 +7,9 @@ var getOriginalPolicy = require('./get/originalPolicy').get;
 var getReferrer = require('./get/referrer').get;
 var getStatusCode = require('./get/statusCode').get;
 var getViolatedDirective = require('./get/violatedDirective').get;
+var getSourceFile = require('./get/sourceFile').get;
+var getColumnNumber = require('./get/columnNumber').get;
+var getLineNumber = require('./get/lineNumber').get;
 
 /**
  * Given a payload, this function normalizes the CSP report to a CSP 2.0 compliant spec.
@@ -16,7 +19,7 @@ var getViolatedDirective = require('./get/violatedDirective').get;
  * @returns {Object}               The normalized CSP report.
  */
 var normalize = function(payload, headers) {
-  return {
+  var report = {
     'csp-report': {
       'document-uri': getDocumentURI(payload),
       'referrer': getReferrer(payload),
@@ -27,6 +30,25 @@ var normalize = function(payload, headers) {
       'status-code': getStatusCode(payload)
     }
   };
+
+  // Only append the following keys if they exist since they are optional
+  var sourceFile = getSourceFile(payload, headers);
+  var lineNumber = getLineNumber(payload);
+  var columnNumber = getColumnNumber(payload);
+
+  if (sourceFile !== '') {
+    report['csp-report']['source-file'] = sourceFile;
+  }
+
+  if (lineNumber !== -1) {
+    report['csp-report']['line-number'] = lineNumber;
+  }
+
+  if (columnNumber !== -1) {
+    report['csp-report']['column-number'] = columnNumber;
+  }
+
+  return report;
 };
 
 module.exports = {

--- a/lib/sanitize/columnNumber.js
+++ b/lib/sanitize/columnNumber.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var isNumeric = require('../util').isNumeric;
+
+/**
+ * Sanitizes a `column-number` value.
+ *
+ * @param  {*}          columnNumber    The raw `column-number` value.
+ * @return {Integer}                    The sanitized `column-number` value.
+ */
+var sanitize = function (columnNumber) {
+  var result = -1;
+
+  if (isNumeric(columnNumber)) {
+    result = parseInt(columnNumber, 10);
+  }
+
+  return result;
+};
+
+module.exports = {
+  sanitize: sanitize
+};

--- a/lib/sanitize/lineNumber.js
+++ b/lib/sanitize/lineNumber.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var isNumeric = require('../util').isNumeric;
+
+/**
+ * Sanitizes a `line-number` value.
+ *
+ * @param  {*}          lineNumber    The raw `line-number` value.
+ * @return {Integer}                  The sanitized `line-number` value.
+ */
+var sanitize = function (lineNumber) {
+  var result = -1;
+
+  if (isNumeric(lineNumber)) {
+    result = parseInt(lineNumber, 10);
+  }
+
+  return result;
+};
+
+module.exports = {
+  sanitize: sanitize
+};

--- a/lib/sanitize/sourceFile.js
+++ b/lib/sanitize/sourceFile.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var isGloballyUniqueIdentifier = require('../util').isGloballyUniqueIdentifier;
+var sanitizeGloballyUniqueIdentifier = require('../util').sanitizeGloballyUniqueIdentifier;
+var url = require('url');
+var validator = require('validator');
+
+/**
+ * Sanitizes a `source-file` value.
+ *
+ * @param  {String}    sourceFile           The raw `source-file` value.
+ * @param  {String}    protectedResource    The URI of the resource protected
+ *                                          by the CSP policy.
+ * @return {String}                         The sanitized `source-file` value.
+ */
+function sanitize(sourceFile, protectedResource) {
+  var result = '';
+  var sourceFilePieces = {};
+  var protectedResourcePieces = {};
+
+  if (true === isGloballyUniqueIdentifier(sourceFile)) {
+    result = sanitizeGloballyUniqueIdentifier(sourceFile);
+  } else if (validator.isURL(sourceFile)) {
+    sourceFilePieces = url.parse(sourceFile);
+
+    // We may not actually have a protected resource passed to the function. In
+    // that case, do not treat the value as a URL
+    if (validator.isURL(protectedResource)) {
+      protectedResourcePieces = url.parse(protectedResource);
+    }
+
+    // If the protected resource's origin is the same as that of the blocked URI
+    // the whole URI can be returned; otherwise, the origin only is returned.
+    if (protectedResourcePieces.host && protectedResourcePieces.protocol && sourceFilePieces.host === protectedResourcePieces.host && sourceFilePieces.protocol === protectedResourcePieces.protocol) {
+      result = sourceFile;
+    } else {
+      result = sourceFilePieces.protocol + '//' + sourceFilePieces.host;
+    }
+  }
+
+  return result;
+}
+
+module.exports = {
+  sanitize: sanitize
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -135,11 +135,22 @@ function parseDirectiveString(directiveString) {
   return directives;
 }
 
+/**
+ * Determines if a value is numeric.
+ *
+ * @param   {*}          value    The value to test.
+ * @returns {boolean}             Whether or not the value is numeric.
+ */
+var isNumeric = function(value) {
+  return !isNaN(parseFloat(value)) && isFinite(value);
+};
+
 module.exports = {
   getGloballyUniqueIdentifiers: getGloballyUniqueIdentifiers,
   isGloballyUniqueIdentifier: isGloballyUniqueIdentifier,
   sanitizeGloballyUniqueIdentifier: sanitizeGloballyUniqueIdentifier,
   getDirectives: getDirectives,
   isEffectiveDirective: isEffectiveDirective,
-  parseDirectiveString: parseDirectiveString
+  parseDirectiveString: parseDirectiveString,
+  isNumeric: isNumeric
 };

--- a/test/lib/extract/columnNumber.js
+++ b/test/lib/extract/columnNumber.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var assert = require('chai').assert;
+var extract = require('../../../lib/extract/columnNumber').extract;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('extract is a function', function() {
+      assert.isFunction(extract);
+    });
+
+    test('extract finds column-number when it exists', function() {
+      var columnNumber = 'http://google.com';
+      var report = {
+        'csp-report': {
+          'column-number': columnNumber
+        }
+      };
+
+      assert.equal(extract(report), columnNumber);
+    });
+
+    test('extract finds column-number when it exists and is an empty string', function() {
+      var columnNumber = '';
+      var report = {
+        'csp-report': {
+          'column-number': columnNumber
+        }
+      };
+
+      assert.equal(extract(report), columnNumber);
+    });
+
+    test('extract returns empty string when `column-number` is not set', function() {
+      var report = {
+        'csp-report': {}
+      };
+
+      assert.equal(extract(report), '');
+    });
+
+    test('extract returns empty string when `csp-report` is not set', function() {
+      var report = {};
+      assert.equal(extract(report), '');
+    });
+  });
+});

--- a/test/lib/extract/lineNumber.js
+++ b/test/lib/extract/lineNumber.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var assert = require('chai').assert;
+var extract = require('../../../lib/extract/lineNumber').extract;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('extract is a function', function() {
+      assert.isFunction(extract);
+    });
+
+    test('extract finds line-number when it exists', function() {
+      var lineNumber = 'http://google.com';
+      var report = {
+        'csp-report': {
+          'line-number': lineNumber
+        }
+      };
+
+      assert.equal(extract(report), lineNumber);
+    });
+
+    test('extract finds line-number when it exists and is an empty string', function() {
+      var lineNumber = '';
+      var report = {
+        'csp-report': {
+          'line-number': lineNumber
+        }
+      };
+
+      assert.equal(extract(report), lineNumber);
+    });
+
+    test('extract returns empty string when `line-number` is not set', function() {
+      var report = {
+        'csp-report': {}
+      };
+
+      assert.equal(extract(report), '');
+    });
+
+    test('extract returns empty string when `csp-report` is not set', function() {
+      var report = {};
+      assert.equal(extract(report), '');
+    });
+  });
+});

--- a/test/lib/extract/sourceFile.js
+++ b/test/lib/extract/sourceFile.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var assert = require('chai').assert;
+var extract = require('../../../lib/extract/sourceFile').extract;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('extract is a function', function() {
+      assert.isFunction(extract);
+    });
+
+    test('extract finds source-file when it exists', function() {
+      var sourceFile = 'http://google.com';
+      var report = {
+        'csp-report': {
+          'source-file': sourceFile
+        }
+      };
+
+      assert.equal(extract(report), sourceFile);
+    });
+
+    test('extract finds source-file when it exists and is an empty string', function() {
+      var sourceFile = '';
+      var report = {
+        'csp-report': {
+          'source-file': sourceFile
+        }
+      };
+
+      assert.equal(extract(report), sourceFile);
+    });
+
+    test('extract returns empty string when `source-file` is not set', function() {
+      var report = {
+        'csp-report': {}
+      };
+
+      assert.equal(extract(report), '');
+    });
+
+    test('extract returns empty string when `csp-report` is not set', function() {
+      var report = {};
+      assert.equal(extract(report), '');
+    });
+  });
+});

--- a/test/lib/get/columnNumber.js
+++ b/test/lib/get/columnNumber.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var assert = require('chai').assert;
+var get = require('../../../lib/get/columnNumber').get;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('get is a function', function() {
+      assert.isFunction(get);
+    });
+
+    test('returns column-number correctly when passed column-number', function() {
+      var columnNumber = 23;
+      var report = {
+        'csp-report': {
+          'column-number': columnNumber
+        }
+      };
+
+      assert.strictEqual(get(report), columnNumber);
+    });
+
+    test('returns -1 when column number is not a number', function() {
+      var columnNumber = 'blah';
+      var report = {
+        'csp-report': {
+          'column-number': columnNumber
+        }
+      };
+
+      assert.strictEqual(get(report), -1);
+    });
+  });
+});

--- a/test/lib/get/lineNumber.js
+++ b/test/lib/get/lineNumber.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var assert = require('chai').assert;
+var get = require('../../../lib/get/lineNumber').get;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('get is a function', function() {
+      assert.isFunction(get);
+    });
+
+    test('returns line-number correctly when passed line-number', function() {
+      var lineNumber = 23;
+      var report = {
+        'csp-report': {
+          'line-number': lineNumber
+        }
+      };
+
+      assert.strictEqual(get(report), lineNumber);
+    });
+
+    test('returns -1 when column number is not a number', function() {
+      var lineNumber = 'blah';
+      var report = {
+        'csp-report': {
+          'line-number': lineNumber
+        }
+      };
+
+      assert.strictEqual(get(report), -1);
+    });
+  });
+});

--- a/test/lib/get/sourceFile.js
+++ b/test/lib/get/sourceFile.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var assert = require('chai').assert;
+var get = require('../../../lib/get/sourceFile').get;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('get is a function', function() {
+      assert.isFunction(get);
+    });
+
+    test('source-file is full path when source-file and referer use the same domain and referer has no path', function() {
+      var url = 'http://example.com';
+      var path = '/test';
+      var payload = {
+        'csp-report': {
+          'source-file': url + path
+        }
+      };
+      var headers = {
+        'referer': url
+      };
+
+      assert.equal(get(payload, headers), url + path);
+    });
+
+    test('source-file is full path when source-file and referer use the same domain and referer has a path', function() {
+      var url = 'http://example.com';
+      var path = '/test';
+      var payload = {
+        'csp-report': {
+          'source-file': url + path
+        }
+      };
+      var headers = {
+        'referer': url + '/test2'
+      };
+
+      assert.equal(get(payload, headers), url + path);
+    });
+
+    test('source-file is domain only when source-file and referer use different domains and referer has no path', function() {
+      var url = 'http://example.com';
+      var path = '/test';
+      var payload = {
+        'csp-report': {
+          'source-file': url + path
+        }
+      };
+      var headers = {
+        'referer': 'http://test.com'
+      };
+
+      assert.equal(get(payload, headers), url);
+    });
+
+    test('source-file is domain only when source-file and referer use different domains and referer has a path', function() {
+      var url = 'http://example.com';
+      var path = '/test';
+      var payload = {
+        'csp-report': {
+          'source-file': url + path
+        }
+      };
+      var headers = {
+        'referer': 'http://test.com/test2'
+      };
+
+      assert.equal(get(payload, headers), url);
+    });
+
+    test('source-file is domain only when no referer is available', function() {
+      var url = 'http://example.com';
+      var path = '/test';
+      var payload = {
+        'csp-report': {
+          'source-file': url + path
+        }
+      };
+
+      assert.equal(get(payload, {}), url);
+    });
+
+    test('empty string when csp-report is set and the source-file is not set', function() {
+      var payload = {
+        'csp-report': ''
+      };
+
+      assert.equal(get(payload, {}), '');
+    });
+
+    test('empty string is used when payload is empty', function() {
+      var payload = {};
+
+      assert.equal(get(payload, {}), '');
+    });
+  });
+});

--- a/test/lib/normalize.js
+++ b/test/lib/normalize.js
@@ -100,4 +100,100 @@ suite(__filename.split('/').pop().replace('.js', ''), function () {
 
     assert.deepEqual(normalize(payload, headers), expected);
   });
+
+  test('appends additional fields if they are present', function () {
+    var payload = {
+      'csp-report': {
+        'document-uri': 'http://example.com/csp?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'referrer': '',
+        'violated-directive': 'child-src https://example.com/',
+        'effective-directive': 'frame-src',
+        'original-policy': 'default-src https://example.com/; child-src https://example.com/; connect-src https://example.com/; font-src https://example.com/; img-src https://example.com/; media-src https://example.com/; object-src https://example.com/; script-src https://example.com/; style-src https://example.com/; form-action https://example.com/; frame-ancestors \'none\'; plugin-types \'none\'; report-uri http://example.com/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'blocked-uri': 'http://google.com',
+        'status-code': 200,
+        'source-file': 'http://example.com/',
+        'column-number': 15,
+        'line-number': 35
+      }
+    };
+    var headers = {
+      'referer': 'http://example.com'
+    };
+
+    assert.deepEqual(normalize(payload, headers), payload);
+  });
+
+  test('truncates source file when present', function () {
+    var payload = {
+      'csp-report': {
+        'document-uri': 'http://example.com/csp?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'referrer': '',
+        'violated-directive': 'child-src https://example.com/',
+        'effective-directive': 'frame-src',
+        'original-policy': 'default-src https://example.com/; child-src https://example.com/; connect-src https://example.com/; font-src https://example.com/; img-src https://example.com/; media-src https://example.com/; object-src https://example.com/; script-src https://example.com/; style-src https://example.com/; form-action https://example.com/; frame-ancestors \'none\'; plugin-types \'none\'; report-uri http://example.com/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'blocked-uri': 'http://google.com',
+        'status-code': 200,
+        'source-file': 'http://test.com/test.js',
+        'column-number': 15,
+        'line-number': 35
+      }
+    };
+    var headers = {
+      'referer': 'http://example.com'
+    };
+
+    // Duplicating this to avoid problematic cloning issues
+    var payloadExpected = {
+      'csp-report': {
+        'document-uri': 'http://example.com/csp?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'referrer': '',
+        'violated-directive': 'child-src https://example.com/',
+        'effective-directive': 'frame-src',
+        'original-policy': 'default-src https://example.com/; child-src https://example.com/; connect-src https://example.com/; font-src https://example.com/; img-src https://example.com/; media-src https://example.com/; object-src https://example.com/; script-src https://example.com/; style-src https://example.com/; form-action https://example.com/; frame-ancestors \'none\'; plugin-types \'none\'; report-uri http://example.com/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'blocked-uri': 'http://google.com',
+        'status-code': 200,
+        'source-file': 'http://test.com',
+        'column-number': 15,
+        'line-number': 35
+      }
+    };
+
+    assert.deepEqual(normalize(payload, headers), payloadExpected);
+  });
+
+  test('does not show column or line number when invalid value', function () {
+    var payload = {
+      'csp-report': {
+        'document-uri': 'http://example.com/csp?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'referrer': '',
+        'violated-directive': 'child-src https://example.com/',
+        'effective-directive': 'frame-src',
+        'original-policy': 'default-src https://example.com/; child-src https://example.com/; connect-src https://example.com/; font-src https://example.com/; img-src https://example.com/; media-src https://example.com/; object-src https://example.com/; script-src https://example.com/; style-src https://example.com/; form-action https://example.com/; frame-ancestors \'none\'; plugin-types \'none\'; report-uri http://example.com/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'blocked-uri': 'http://google.com',
+        'status-code': 200,
+        'source-file': 'http://test.com',
+        'column-number': 'blah',
+        'line-number': 'what'
+      }
+    };
+    var headers = {
+      'referer': 'http://example.com'
+    };
+
+    // Duplicating this to avoid problematic cloning issues
+    var payloadExpected = {
+      'csp-report': {
+        'document-uri': 'http://example.com/csp?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'referrer': '',
+        'violated-directive': 'child-src https://example.com/',
+        'effective-directive': 'frame-src',
+        'original-policy': 'default-src https://example.com/; child-src https://example.com/; connect-src https://example.com/; font-src https://example.com/; img-src https://example.com/; media-src https://example.com/; object-src https://example.com/; script-src https://example.com/; style-src https://example.com/; form-action https://example.com/; frame-ancestors \'none\'; plugin-types \'none\'; report-uri http://example.com/csp-report?os=OS%20X&device=&browser_version=43.0&browser=chrome&os_version=Lion',
+        'blocked-uri': 'http://google.com',
+        'status-code': 200,
+        'source-file': 'http://test.com'
+      }
+    };
+
+    assert.deepEqual(normalize(payload, headers), payloadExpected);
+  });
 });

--- a/test/lib/sanitize/columnNumber.js
+++ b/test/lib/sanitize/columnNumber.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var assert = require('chai').assert;
+var sanitize = require('../../../lib/sanitize/columnNumber').sanitize;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('sanitize is a function', function() {
+      assert.isFunction(sanitize);
+    });
+
+    test('returns Integer for numeric values', function() {
+      assert.strictEqual(sanitize(-1), -1);
+      assert.strictEqual(sanitize(0), 0);
+      assert.strictEqual(sanitize(1), 1);
+
+      assert.strictEqual(sanitize('-1'), -1);
+      assert.strictEqual(sanitize('0'), 0);
+      assert.strictEqual(sanitize('1'), 1);
+
+      assert.strictEqual(sanitize(-1.5), -1);
+      assert.strictEqual(sanitize(0.0), 0);
+      assert.strictEqual(sanitize(1.0), 1);
+
+      assert.strictEqual(sanitize('-1.5'), -1);
+      assert.strictEqual(sanitize('0.0'), 0);
+      assert.strictEqual(sanitize('1.0'), 1);
+    });
+    
+    test('returns -1 for non-numeric values', function() {
+      assert.strictEqual(sanitize('a'), -1);
+      assert.strictEqual(sanitize({}), -1);
+      assert.strictEqual(sanitize([]), -1);
+      assert.strictEqual(sanitize(null), -1);
+      assert.strictEqual(sanitize(function(){}), -1);
+    });
+  });
+});

--- a/test/lib/sanitize/lineNumber.js
+++ b/test/lib/sanitize/lineNumber.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var assert = require('chai').assert;
+var sanitize = require('../../../lib/sanitize/lineNumber').sanitize;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('sanitize is a function', function() {
+      assert.isFunction(sanitize);
+    });
+
+    test('returns Integer for numeric values', function() {
+      assert.strictEqual(sanitize(-1), -1);
+      assert.strictEqual(sanitize(0), 0);
+      assert.strictEqual(sanitize(1), 1);
+
+      assert.strictEqual(sanitize('-1'), -1);
+      assert.strictEqual(sanitize('0'), 0);
+      assert.strictEqual(sanitize('1'), 1);
+
+      assert.strictEqual(sanitize(-1.5), -1);
+      assert.strictEqual(sanitize(0.0), 0);
+      assert.strictEqual(sanitize(1.0), 1);
+
+      assert.strictEqual(sanitize('-1.5'), -1);
+      assert.strictEqual(sanitize('0.0'), 0);
+      assert.strictEqual(sanitize('1.0'), 1);
+    });
+
+    test('returns -1 for non-numeric values', function() {
+      assert.strictEqual(sanitize('a'), -1);
+      assert.strictEqual(sanitize({}), -1);
+      assert.strictEqual(sanitize([]), -1);
+      assert.strictEqual(sanitize(null), -1);
+      assert.strictEqual(sanitize(function(){}), -1);
+    });
+  });
+});

--- a/test/lib/sanitize/sourceFile.js
+++ b/test/lib/sanitize/sourceFile.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var assert = require('chai').assert;
+var sanitize = require('../../../lib/sanitize/sourceFile').sanitize;
+
+suite(__dirname.split('/').pop(), function() {
+  suite(__filename.split('/').pop().replace('.js', ''), function() {
+    test('sanitize is a function', function() {
+      assert.isFunction(sanitize);
+    });
+
+    test('convert data URIs to data', function() {
+      assert.equal(sanitize('data:xxxxxxxx'), 'data');
+    });
+
+    test('convert filesystem URIs to filesystem', function() {
+      assert.equal(sanitize('filesystem:xxxxxxxx'), 'filesystem');
+    });
+
+    test('convert blob URIs to blob', function() {
+      assert.equal(sanitize('blob:xxxxxxxx'), 'blob');
+    });
+
+    test('convert a non-URI string to an empty string', function() {
+      assert.equal(sanitize('test', {}), '');
+    });
+
+    test('return the origin of a blocked URI when it does not match the protected resource\'s origin', function() {
+      assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.another-example.com'), 'http://www.example.com');
+    });
+
+    test('return the origin of a blocked URI when it does not match the protected resource\'s origin and the resource has a path', function() {
+      assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.another-example.com/yolo'), 'http://www.example.com');
+    });
+
+    test('return the full blocked URI when it matches the protected resource\'s origin', function() {
+      assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.example.com'), 'http://www.example.com/hello-world');
+    });
+
+    test('return the full blocked URI when it matches the protected resource\'s origin and the resource has a path', function() {
+      assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.example.com/testing'), 'http://www.example.com/hello-world');
+    });
+
+    test('return the blocked URI origin when it matches the protected resource\'s origin, but not protocol', function() {
+      assert.equal(sanitize('http://www.example.com/hello-world', 'https://www.example.com/testing'), 'http://www.example.com');
+    });
+  });
+});

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -166,4 +166,34 @@ suite(__filename.split('/').pop().replace('.js', ''), function() {
       assert.deepEqual(util.parseDirectiveString(directiveString), expected);
     });
   });
+
+  suite('other functions', function() {
+    suite('isNumeric', function() {
+      test('true when passed numbers', function() {
+        assert.isTrue(util.isNumeric(-1));
+        assert.isTrue(util.isNumeric(0));
+        assert.isTrue(util.isNumeric(1));
+
+        assert.isTrue(util.isNumeric('-1'));
+        assert.isTrue(util.isNumeric('0'));
+        assert.isTrue(util.isNumeric('1'));
+
+        assert.isTrue(util.isNumeric(-1.5));
+        assert.isTrue(util.isNumeric(0.0));
+        assert.isTrue(util.isNumeric(1.0));
+
+        assert.isTrue(util.isNumeric('-1.5'));
+        assert.isTrue(util.isNumeric('0.0'));
+        assert.isTrue(util.isNumeric('1.0'));
+      });
+
+      test('false when passed non-numbers', function() {
+        assert.isFalse(util.isNumeric('a'));
+        assert.isFalse(util.isNumeric({}));
+        assert.isFalse(util.isNumeric([]));
+        assert.isFalse(util.isNumeric(null));
+        assert.isFalse(util.isNumeric(function(){}));
+      });
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces source-file, column-number, and line-number, the
additional fields missing the module. Logic is added to ensure that the
values are only included when they are available.

Related: https://github.com/tollmanz/csp-report-norm/issues/7
