### PR TITLE
Don't require protocol matches for full blockedURI

### DIFF
--- a/lib/sanitize/blockedURI.js
+++ b/lib/sanitize/blockedURI.js
@@ -48,7 +48,7 @@ function sanitize(blockedURI, protectedResource) {
 
     // If the protected resource's origin is the same as that of the blocked URI
     // the whole URI can be returned; otherwise, the origin only is returned.
-    if (protectedResourcePieces.host && protectedResourcePieces.protocol && blockedURIPieces.host === protectedResourcePieces.host && blockedURIPieces.protocol === protectedResourcePieces.protocol) {
+    if (protectedResourcePieces.host && blockedURIPieces.host === protectedResourcePieces.host) {
       result = blockedURI;
     } else {
       result = blockedURIPieces.protocol + '//' + blockedURIPieces.host;

--- a/test/lib/sanitize/blockedURI.js
+++ b/test/lib/sanitize/blockedURI.js
@@ -10,43 +10,47 @@ suite(__dirname.split('/').pop(), function() {
       test('sanitize is a function', function() {
         assert.isFunction(sanitize);
       });
-  
+
       test('convert data URIs to data', function() {
         assert.equal(sanitize('data:xxxxxxxx'), 'data');
       });
-  
+
       test('convert filesystem URIs to filesystem', function() {
         assert.equal(sanitize('filesystem:xxxxxxxx'), 'filesystem');
       });
-  
+
       test('convert blob URIs to blob', function() {
         assert.equal(sanitize('blob:xxxxxxxx'), 'blob');
       });
-  
+
       test('convert a non-URI string to an empty string', function() {
         assert.equal(sanitize('test', {}), '');
       });
-  
+
       test('return the origin of a blocked URI when it does not match the protected resource\'s origin', function() {
         assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.another-example.com'), 'http://www.example.com');
       });
-  
+
       test('return the origin of a blocked URI when it does not match the protected resource\'s origin and the resource has a path', function() {
         assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.another-example.com/yolo'), 'http://www.example.com');
       });
-  
+
       test('return the full blocked URI when it matches the protected resource\'s origin', function() {
         assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.example.com'), 'http://www.example.com/hello-world');
       });
-  
+
       test('return the full blocked URI when it matches the protected resource\'s origin and the resource has a path', function() {
         assert.equal(sanitize('http://www.example.com/hello-world', 'http://www.example.com/testing'), 'http://www.example.com/hello-world');
       });
-  
-      test('return the blocked URI origin when it matches the protected resource\'s origin, but not protocol', function() {
-        assert.equal(sanitize('http://www.example.com/hello-world', 'https://www.example.com/testing'), 'http://www.example.com');
+
+      test('return the full URI when protocol does not match', function() {
+        assert.equal(sanitize('http://www.example.com/hello-world', 'https://www.example.com/testing'), 'http://www.example.com/hello-world');
       });
-  
+
+      test('return the host only when hosts don`t match but protocols do', function() {
+        assert.equal(sanitize('https://www.examples.com/hello-world', 'https://www.example.com/testing'), 'https://www.examples.com');
+      });
+
       test('return a special case blocked URI', function() {
         assert.equal(sanitize('about', 'https://www.example.com/testing'), 'about');
       });


### PR DESCRIPTION
After reviewing the spec, I realized there was an issue with how the
full blocked URI was evaluated. The hosts must match in order for a
full URI to be used; however, the protocol does not need to match. This
disparity has been resolved.
