### PR TITLE
Whitelist more protocols

### DIFF
--- a/lib/sanitize/blockedURI.js
+++ b/lib/sanitize/blockedURI.js
@@ -12,12 +12,37 @@ var validator = require('validator');
  * @returns {boolean}                  Whether or not the value is allowed.
  */
 function isSpecialCase(blockedURI) {
+  var result = false;
   var specialCases = [
     'about',
-    'about:blank'
+    'about:blank',
+    'android-webview',
+    'android-webview-video-poster',
+    'ms-appx-web://',
+    'chrome-extension://',
+    'safari-extension://',
+    'mxjscall://',
+    'webviewprogressproxy://',
+    'res://',
+    'mx://',
+    'safari-resource://',
+    'chromenull://',
+    'chromeinvoke://',
+    'chromeinvokeimmediate://',
+    'mbinit://',
+    'opera://',
+    'localhost',
+    '127.0.0.1',
+    'none://'
   ];
 
-  return (specialCases.indexOf(blockedURI.trim()) >= 0);
+  specialCases.forEach(function(specialCase) {
+    if (specialCase.indexOf(blockedURI.trim()) === 0) {
+      result = true;
+    }
+  });
+
+  return result;
 }
 
 /**

--- a/test/lib/sanitize/blockedURI.js
+++ b/test/lib/sanitize/blockedURI.js
@@ -68,6 +68,12 @@ suite(__dirname.split('/').pop(), function() {
         assert.equal(isSpecialCase(' about:blank '), true);
         assert.equal(isSpecialCase('about:blank '), true);
         assert.equal(isSpecialCase('    about:blank     '), true);
+
+        assert.equal(isSpecialCase('chromenull://'), true);
+        assert.equal(isSpecialCase(' chromenull://'), true);
+        assert.equal(isSpecialCase(' chromenull:// '), true);
+        assert.equal(isSpecialCase('chromenull:// '), true);
+        assert.equal(isSpecialCase('    chromenull://     '), true);
       });
     });
   });


### PR DESCRIPTION
Allows more protocols to produce valid reports. Just because one would
likely dispose of these reports, it does not make them invalid. Capture
them still without nullifying the data.
