### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 coverage
 .idea
+yarn.lock


### PR DESCRIPTION
For those of us using [Yarn](https://yarnpkg.com/), this just adds the Yarn lock file to `.gitignore`.